### PR TITLE
Fix docs doing inherited members

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,0 +1,33 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   {% block methods %}
+   .. automethod:: __init__
+
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+   {% for item in methods %}
+      {%- if item not in inherited_members %}
+         {%- if not item.startswith('_') or item in ['__call__', '__mul__', '__getitem__', '__len__'] %}
+            ~{{ name }}.{{ item }}
+         {% endif %}
+      {% endif %}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/apidocs/circuit_runner.rst
+++ b/docs/apidocs/circuit_runner.rst
@@ -1,3 +1,3 @@
 .. _qiskit_runtime-circuit_runner:
 
-.. automodapi:: qiskit_runtime.circuit_runner
+.. automodule:: qiskit_runtime.circuit_runner

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
     'jupyter_sphinx',
-    'sphinx_automodapi.automodapi'
 ]
 html_static_path = ['_static']
 templates_path = ['_templates']
@@ -86,8 +85,6 @@ autosummary_generate = True
 # -----------------------------------------------------------------------------
 # Autodoc
 # -----------------------------------------------------------------------------
-
-automodsumm_inherited_members = False
 
 autoclass_content = 'init'
 

--- a/qiskit_runtime/circuit_runner/__init__.py
+++ b/qiskit_runtime/circuit_runner/__init__.py
@@ -12,6 +12,26 @@
 
 """
 Qiskit circuit runner module
+============================
+
+.. currentmodule:: qiskit_runtime.circuit_runner
+
+Result class
+--------------
+
+.. autosummary::
+   :toctree: ../stubs/
+
+    RunnerResult
+
+Distributions
+-------------
+
+.. autosummary::
+   :toctree: ../stubs/
+
+    ProbDistribution
+    QuasiDistribution
 """
 
 from .result import RunnerResult

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,4 @@
 Sphinx>=3.3
-sphinx-automodapi
 sphinx-autodoc-typehints
 jupyter-sphinx
 qiskit-sphinx-theme>=1.8.0


### PR DESCRIPTION
This is a fix for the long long long standing issue of classes listing their inherited members in their doc strings.  Will port this over to Terra as well where most of the docs build time is in the library that subclasses `QuantumCircuit`