### PR TITLE
Remove program update from title

### DIFF
--- a/tutorials/Uploading_program.ipynb
+++ b/tutorials/Uploading_program.ipynb
@@ -547,7 +547,7 @@
    "id": "a0259d71",
    "metadata": {},
    "source": [
-    "## Deleting and updating a program"
+    "## Deleting a program"
    ]
   },
   {


### PR DESCRIPTION
#14 removed `update_program()` (since it no longer works) but the section title still had `## Deleting and updating a program`