### PR TITLE
Add links to program template

### DIFF
--- a/tutorials/Uploading_program.ipynb
+++ b/tutorials/Uploading_program.ipynb
@@ -39,7 +39,8 @@
    "id": "79d64290",
    "metadata": {},
    "source": [
-    "Below is a template of a runtime program:"
+    "Below is a template of a runtime program. You can find the template file in the \n",
+    "[`qiskit-ibmq-provider`](https://github.com/Qiskit/qiskit-ibmq-provider/blob/master/qiskit/providers/ibmq/runtime/program/program_template.py) repository."
    ]
   },
   {
@@ -167,7 +168,9 @@
    "id": "8d938353",
    "metadata": {},
    "source": [
-    "If you want to pass custom Python classes, the `RuntimeEncoder` and `RuntimeDecoder` methods have some support for that. You can define a `to_json()` method that returns a JSON string representation of the object, and a `from_json()` class method that accepts a JSON string and returns the corresponding object. When `RuntimeEncoder` serializes a Python object, it checks whether the object has a `to_json()` method. If so, it uses the method for serialization. `RuntimeDecoder`, however, does _not_ invoke `from_json()` to convert the data back because it doesn't know how to import your custom class. You can, however, create your own decoder."
+    "If you want to pass custom Python classes, the `RuntimeEncoder` and `RuntimeDecoder` methods have some support for that. In your custom class, you can define a `to_json()` method that returns a JSON string representation of the object, and a `from_json()` class method that accepts a JSON string and returns the corresponding object. When `RuntimeEncoder` serializes a Python object, it checks whether the object has a `to_json()` method. If so, it uses the method for serialization. `RuntimeDecoder`, however, does _not_ invoke `from_json()` to convert the data back because it doesn't know how to import your custom class. You can, however, create your own decoder.\n",
+    "\n",
+    "You decoder should inherit the [`ResultDecoder`](https://qiskit.org/documentation/stubs/qiskit.providers.ibmq.runtime.ResultDecoder.html#qiskit.providers.ibmq.runtime.ResultDecoder) class and overwrites its `decode()` method. This `decode()` method is called to deserialize job results. Your subclass can call the parent's ``decode()`` method to handle deserialization of other result data, and the subclass can handle just the custom class. "
    ]
   },
   {
@@ -306,7 +309,7 @@
     "\n",
     "    @classmethod\n",
     "    def decode(cls, data):\n",
-    "        decoded = super().decode(data)\n",
+    "        decoded = super().decode(data)  # Call parent method to handle other data.\n",
     "        decoded[\"my_obj\"] = MyCustomClass.from_json(decoded[\"my_obj\"])\n",
     "        return decoded"
    ]


### PR DESCRIPTION
This PR updates the "uploading_program" tutorial to add links to the program template and to the `ResultDecoder` class doc. 