### PR TITLE
Add qiskit_runtime to path

### DIFF
--- a/tutorials/02_circuit_runner.ipynb
+++ b/tutorials/02_circuit_runner.ipynb
@@ -17,17 +17,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "48d7f58b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# First prepare all dependencies\n",
-    "import prep_dependency"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "3ec31be3",
    "metadata": {},

--- a/tutorials/02_circuit_runner.ipynb
+++ b/tutorials/02_circuit_runner.ipynb
@@ -17,6 +17,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "48d7f58b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First prepare all dependencies\n",
+    "import prep_dependency"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "3ec31be3",
    "metadata": {},
@@ -372,14 +383,6 @@
     "import qiskit.tools.jupyter\n",
     "%qiskit_version_table"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3a362dcb",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/prep_dependency.py
+++ b/tutorials/prep_dependency.py
@@ -1,0 +1,16 @@
+# This code is part of qiskit-runtime.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import sys
+
+# Add qiskit_runtime directory to the path
+sys.path.insert(0, '..')

--- a/tutorials/vqe.ipynb
+++ b/tutorials/vqe.ipynb
@@ -13,6 +13,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First prepare all dependencies\n",
+    "import prep_dependency"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -688,7 +698,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
@ismaelfaro @nonhermitian @Cryoris If `qiskit-runtime` will not be pip installable, then one quick work around is to add the `qiskit_runtime` directory to the path. This PR adds a Python module `prep_dependency` (feel free to suggest a different name) that does just that. I updated the VQE tutorial to import that module, and the rest of the tutorial can stay the same.

But I'm not a notebook expert so perhaps there are better ways?