### PR TITLE
Update installation wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,18 @@ but check back, as we’ll be releasing it publicly soon!
 
 ## Installation
 
-You need to have the last version of [Qiskit](https://qiskit.org) and of [Qiskit IBM Quantum providers](https://github.com/Qiskit/qiskit-ibmq-provider) installed, in that case you can download this repository and use Jupyter Notebook/Lab to explore the tutorial and learn how Qiskit Runtime works.
+You need to install the required packages needed for the tutorials, which is documented in `requirements.txt`.
+After that, you can download this repository and use Jupyter Notebook/Lab to explore the 
+tutorials and learn how Qiskit Runtime works.
 
-'''bash
-pip install qiskit -U
-
+```bash
 git clone https://github.com/Qiskit-Partners/qiskit-runtime.git
+cd qiskit-runtime
+pip install -r requirements.txt
 
 cd qiskit-runtime/tutorials
 jupyter notebook .
-''' 
+```
 
 ## Executing a runtime program
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-jupyter
 qiskit-aer
 pytest
 black==21.5b0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 qiskit-terra>=0.17
 qiskit-ibmq-provider>=0.13.0
+jupyter
+numpy
+matplotlib
+pylatexenc


### PR DESCRIPTION
This PR updates the READ to say to install from `requirements.txt` since there are additional requirements (e.g. `jupyter` itself) needed to run the tutorials.