### PR TITLE
Move REST API to navbar

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -95,7 +95,9 @@
           <li {%- if pagename == 'tutorials' %} class="active"{% endif %}>
             <a href="{{ pathto('tutorials') }}">Tutorials</a>
           </li>
-
+          <li>
+            <a href="{{ theme_variables.external_urls['api'] }}">REST API</a>
+          </li>
           <li>
             <a href="{{ theme_variables.external_urls['docs'] }}" target="_blank">Qiskit documentation</a>
           </li>
@@ -280,6 +282,9 @@
           </li>
           <li>
             <a href="{{ pathto('tutorials') }}">Tutorials</a>
+          </li>
+          <li>
+            <a href="{{ theme_variables.external_urls['api'] }}">REST API</a>
           </li>
           <li>
             <a href="{{ theme_variables.external_urls['docs'] }}">Qiskit documentation</a>

--- a/docs/_templates/theme_variables.jinja
+++ b/docs/_templates/theme_variables.jinja
@@ -3,6 +3,7 @@
   'github_issues': 'https://github.com/Qiskit-Partners/qiskit-runtime/issues',
   'contributing': 'https://github.com/Qiskit/qiskit/blob/master/CONTRIBUTING.md',
   'docs': 'https://qiskit.org/documentation/',
+  'api': 'https://runtime-us-east.quantum-computing.ibm.com/openapi/',
   'ml': 'https://qiskit.org/documentation/machine-learning/',
   'nature': 'https://qiskit.org/documentation/nature/',
   'finance': 'https://qiskit.org/documentation/finance/',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ Qiskit runtime (|version|)
 The Qiskit runtime is a new execution model / architecture that markedly reduces
 IO overhead when submitting applications and algorithms to quantum processors that
 require many iterations of circuit executions and classical processing.  Programs of this
-category are common, and span a wide variety of applications spaces including chemistry,
+category are common, and span a wide variety of application spaces including chemistry,
 machine learning, and optimization.  
 
 .. figure:: images/runtime_arch.png
@@ -42,7 +42,6 @@ For additional information and usage examples see the :ref:`tutorials` page.
     self
     Getting starting <getting_started>
     Current runtime limitations <limitations>
-    REST API <https://runtime-us-east.quantum-computing.ibm.com/openapi/>
 
 
 .. toctree::


### PR DESCRIPTION
moves the rest api link to the navbar from the sidebar