### PR TITLE
Publish docs on merges with main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,7 @@
 name: Docs Publish
 on:
   push:
-    tags:
-      - "*"
+    branches: [ main ]
 
 jobs:
   deploy:


### PR DESCRIPTION
Since we are not planning on using this repo in published form, we need to trigger the docs publishing on merges to main rather than deployment tags