### PR TITLE
Add instruction on querying for runtime backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ authorized users can then invoke these quantum programs by simply passing in the
 
 ---
 
-:warning:  Qiskit Runtime is now available on the ``ibmq_qasm_simulator`` for all premium users to 
-try out. Some members of the IBM Quantum Network also have Qiskit Runtime access in private beta mode 
-on ``ibmq_montreal``.
+:warning: Qiskit Runtime is now available on select IBM Quantum systems and simulators 
+for all premium users to try out. We will be adding more systems and will be releasing it to all users soon! 
 
 ---
 
@@ -48,6 +47,34 @@ your first time using IBM Quantum or Qiskit, please refer to the instruction in 
 [`qiskit-ibmq-provider`](https://github.com/Qiskit/qiskit-ibmq-provider#configure-your-ibm-quantum-experience-credentials)
 repository to configure your IBM Quantum credentials.
 
+### Checking for access
+
+You can use the `has_service()` method to check whether you have access to Qiskit Runtime:
+
+```python
+from qiskit import IBMQ
+
+provider = IBMQ.load_account()
+print(f"Do I have access to Qiskit Runtime? {provider.has_service('runtime')}")
+```
+
+### Checking for backend support
+
+A backend supports Qiskit Runtime if it has `runtime` in the `input_allowed` configuration attribute:
+
+```python
+backend = provider.backend.ibmq_montreal
+support_runtime = 'runtime' in backend.configuration().input_allowed
+print(f"Does {backend.name()} support Qiskit Runtime? {support_runtime}")
+```
+
+You can also use `input_allowed` as a filter in `backends()` (requires Qiskit 0.27.0 or later):
+
+```python
+# Get a list of all backends that support runtime.
+runtime_backends = provider.backends(input_allowed='runtime')
+print(f"Backends that support Qiskit Runtime: {runtime_backends}")
+```
 
 ### Finding available programs
 
@@ -171,12 +198,6 @@ print(f"input payload size={sys.getsizeof(serialized)}")  # Size needs to be sma
 This roughly translates into a five circuit maximum per job.
 
 If your payload is too large, you'll get an error message `'exec user process caused "argument list too long"'`.
-
-
-### Backends
-
-Currently the only backends that support Qiskit Runtime are `ibmq_montreal` for select IBM Quantum
-Network users and `ibmq_qasm_simulator` for all premium users.
 
 ### API
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,10 +4,9 @@ Qiskit Runtime (|version|)
 
 .. important:: 
 
-    The Qiskit Runtime is currently in beta mode, and is in limited release.
-    Those interested in using the Qiskit Runtime can
-    `request access <https://airtable.com/shrm6zyNBns86hB4C>`_.
-
+    The Qiskit Runtime is currently in beta mode and is available on
+    select IBM Quantum systems and simulators to all premium users.
+    But check back, as we’ll be releasing it publicly soon!
 
 The Qiskit Runtime is a new execution model / architecture that markedly reduces
 IO overhead when submitting applications and algorithms to quantum processors that

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -11,8 +11,20 @@ Runtime limitations
 
 - **Limited quantum systems available for Qiskit Runtime**
    
-   Currently only the *ibmq_montreal* and *ibmq_qasm_simulator* are accessible
-   via the Qiskit runtime architecture.
+   Not all systems and simulators support Qiskit Runtime.
+   A backend supports Qiskit Runtime if it has ``runtime`` in the ``input_allowed``
+   configuration attribute::
+
+      backend = provider.backend.ibmq_montreal
+      support_runtime = 'runtime' in backend.configuration().input_allowed
+      print(f"Does {backend.name()} support Qiskit Runtime? {support_runtime}")
+
+   You can also use ``input_allowed`` as a filter in ``backends()``
+   (requires Qiskit 0.27.0 or later)::
+
+      # Get a list of all backends that support runtime.
+      runtime_backends = provider.backends(input_allowed='runtime')
+      print(f"Backends that support Qiskit Runtime: {runtime_backends}")
 
 - **Uploading custom quantum programs not supported**
    


### PR DESCRIPTION
We now have the ability to query for backends that support Qiskit Runtime. This PR adds the steps in README and docs.