### PR TITLE
update upload tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Using Qiskit Runtime, for example, a research team at IBM Quantum was able to ac
 up in their lithium hydride simulation. For more information, see the 
 [IBM Research blog](https://research.ibm.com/blog/120x-quantum-speedup) 
 
-Qiskit Runtime allows authorized users to upload their Qiskit quantum programs for themselves or 
+Qiskit Runtime allows premium users to upload their Qiskit quantum programs for themselves or 
 others to use. A Qiskit quantum program, also called a Qiskit runtime program, is a piece of Python code that takes certain inputs, performs
 quantum and maybe classical computation, and returns the processing results. The same or other
 authorized users can then invoke these quantum programs by simply passing in the required input parameters.

--- a/tutorials/02_uploading_program.ipynb
+++ b/tutorials/02_uploading_program.ipynb
@@ -19,7 +19,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "Here we provide an overview on how to construct and upload a runtime program. A runtime program is a piece of Python code that lives in the cloud and can be invoked by other authorized users. Runtime programs are **private** by default, but the program visibility can be changed during upload or at a later time."
+    "Here we provide an overview on how to construct and upload a runtime program, available to premium users. A runtime program is a piece of Python code that lives in the cloud and can be invoked by other authorized users. Runtime programs are **private** by default, but the program visibility can be changed during upload or at a later time."
    ],
    "metadata": {}
   },
@@ -478,7 +478,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "You can use the [`IBMRuntimeService.upload_program()`](https://qiskit.org/documentation/stubs/qiskit.providers.ibmq.runtime.IBMRuntimeService.html#qiskit.providers.ibmq.runtime.IBMRuntimeService.upload_program) method to upload your program. In the example below, the program data lives in the file `sample_program.py`, and its metadata, as described above, is in `sample_program.json`. "
+    "Premium users can use the [`IBMRuntimeService.upload_program()`](https://qiskit.org/documentation/stubs/qiskit.providers.ibmq.runtime.IBMRuntimeService.html#qiskit.providers.ibmq.runtime.IBMRuntimeService.upload_program) method to upload their program. In the example below, the program data lives in the file `sample_program.py`, and its metadata, as described above, is in `sample_program.json`. "
    ],
    "metadata": {}
   },
@@ -544,12 +544,12 @@
     {
      "output_type": "display_data",
      "data": {
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ],
       "text/html": [
        "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>None</td></tr><tr><td>Terra</td><td>0.17.1</td></tr><tr><td>Aer</td><td>0.8.2</td></tr><tr><td>Ignis</td><td>None</td></tr><tr><td>Aqua</td><td>None</td></tr><tr><td>IBM Q Provider</td><td>0.13.0</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.9.1 (default, Feb  5 2021, 11:23:59) \n",
        "[Clang 12.0.0 (clang-1200.0.32.28)]</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>16.0</td></tr><tr><td colspan='2'>Thu May 06 20:23:17 2021 EDT</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {}


### PR DESCRIPTION
Closes: https://zenhub.ibm.com/app/workspaces/provider-planning-613906b5825e5287a4f286e3/issues/ibm-q-software/provider-planning/20

Update tutorial/readme to reflect premium users can upload runtime programs.