### PR TITLE
Circuit runner tutorial not using proper format

### DIFF
--- a/tutorials/01_circuit_runner.ipynb
+++ b/tutorials/01_circuit_runner.ipynb
@@ -569,7 +569,7 @@
     }
    ],
    "source": [
-    "quasi = res3.get_quasiprobabilities()\n",
+    "quasi = res3.get_quasiprobabilities().binary_probabilities()\n",
     "quasi"
    ]
   },
@@ -618,7 +618,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nearest_probs = quasi.nearest_probability_distribution()"
+    "nearest_probs = quasi.nearest_probability_distribution().binary_probabilities()"
    ]
   },
   {

--- a/tutorials/01_circuit_runner.ipynb
+++ b/tutorials/01_circuit_runner.ipynb
@@ -53,27 +53,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "90a4c6ef",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "provider.has_service('runtime')"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "ee1e3511",
    "metadata": {},

--- a/tutorials/01_circuit_runner.ipynb
+++ b/tutorials/01_circuit_runner.ipynb
@@ -310,7 +310,7 @@
       "  Description: A runtime program that takes one or more circuits, compiles them, executes them, and optionally applies measurement error mitigation.\n",
       "  Version: 1\n",
       "  Creation date: 2021-05-07T00:17:07Z\n",
-      "  Max execution time: 1800\n",
+      "  Max execution time: 28800\n",
       "  Input parameters:\n",
       "    - circuits:\n",
       "      Description: A circuit or a list of circuits.\n",
@@ -625,7 +625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "id": "32e72f51",
    "metadata": {},
    "outputs": [
@@ -635,7 +635,7 @@
        "0.9255895675305238"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -656,7 +656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "6ffd5b04",
    "metadata": {},
    "outputs": [
@@ -666,7 +666,7 @@
        "0.008146638981997967"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -685,7 +685,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "1251442e",
    "metadata": {},
    "outputs": [
@@ -695,7 +695,7 @@
        "{'0': 0, '1': 1, '4': 2, '7': 3, '10': 4, '12': 5}"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/tutorials/01_circuit_runner.ipynb
+++ b/tutorials/01_circuit_runner.ipynb
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "84785ee9",
    "metadata": {},
    "outputs": [
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "e01c0503",
    "metadata": {
     "tags": [
@@ -154,7 +154,7 @@
        "<Figure size 839.279x445.48 with 1 Axes>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -176,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "f36f8eb8",
    "metadata": {},
    "outputs": [],
@@ -206,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "08de9773",
    "metadata": {},
    "outputs": [],
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "8356e156",
    "metadata": {},
    "outputs": [],
@@ -226,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "738dbad1",
    "metadata": {},
    "outputs": [],
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "4cf377ee",
    "metadata": {},
    "outputs": [
@@ -247,7 +247,7 @@
        "<Figure size 1080x432 with 1 Axes>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -266,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "3dfd52a7",
    "metadata": {},
    "outputs": [
@@ -276,7 +276,7 @@
        "0.839082737475692"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -297,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "23de57a7",
    "metadata": {},
    "outputs": [
@@ -384,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "204aad90",
    "metadata": {},
    "outputs": [],
@@ -412,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "9955d4d3",
    "metadata": {},
    "outputs": [],
@@ -422,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "55c59d81",
    "metadata": {},
    "outputs": [
@@ -432,7 +432,7 @@
        "0.794535071278472"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -453,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "b2c1990e",
    "metadata": {},
    "outputs": [],
@@ -464,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "e0b476e8",
    "metadata": {},
    "outputs": [],
@@ -482,7 +482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "id": "fb8676ac",
    "metadata": {},
    "outputs": [
@@ -542,14 +542,15 @@
        " '111111': 0.4123394393204907}"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "quasi = res3.get_quasiprobabilities().binary_probabilities()\n",
-    "quasi"
+    "quasi = res3.get_quasiprobabilities()\n",
+    "quasi_binary = quasi.binary_probabilities()\n",
+    "quasi_binary"
    ]
   },
   {
@@ -562,7 +563,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "id": "fd8b7452",
    "metadata": {},
    "outputs": [
@@ -578,7 +579,7 @@
    ],
    "source": [
     "print(\"Raw expectation value:\", expectation_value(res3.get_counts())[0])\n",
-    "print(\"Mitigated expectation value:\", expectation_value(quasi)[0])\n",
+    "print(\"Mitigated expectation value:\", expectation_value(quasi_binary)[0])\n",
     "print(\"Exact expectation value:\", expectation_value(exact_dist)[0])"
    ]
   },
@@ -592,7 +593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "id": "c5daccf0",
    "metadata": {},
    "outputs": [],
@@ -602,7 +603,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "id": "e5c7f20e",
    "metadata": {},
    "outputs": [
@@ -613,7 +614,7 @@
        "<Figure size 1080x432 with 1 Axes>"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -624,7 +625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "id": "32e72f51",
    "metadata": {},
    "outputs": [
@@ -634,7 +635,7 @@
        "0.9255895675305238"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -655,7 +656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "id": "6ffd5b04",
    "metadata": {},
    "outputs": [
@@ -665,7 +666,7 @@
        "0.008146638981997967"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -684,7 +685,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "id": "1251442e",
    "metadata": {},
    "outputs": [
@@ -694,7 +695,7 @@
        "{'0': 0, '1': 1, '4': 2, '7': 3, '10': 4, '12': 5}"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
I'm not sure how this worked before. [RunnerResult.get_quasiprobabilities()](https://github.com/Qiskit/qiskit-ibmq-provider/blob/master/qiskit/providers/ibmq/runner_result.py#L33) returns a dictionary whose keys are integers, _not_ binary strings. The `expectation_value()` and `plot_histogram()` functions, however, expect the binary strings format (same format as `get_counts()`). This PR calls `binary_probabilities()` to convert the format before passing to those functions. 